### PR TITLE
Hide the scrollbars of large-container element

### DIFF
--- a/style.css
+++ b/style.css
@@ -136,7 +136,7 @@ p, .textcontainer {
 }
 
 .large-container {
-  overflow: auto;
+  overflow: hidden;
   display: block;
   text-align: center;
   margin: 0 auto;


### PR DESCRIPTION
This prevents unwanted scrollbars to appear when the element is animated.
### Before

![out](https://cloud.githubusercontent.com/assets/2864371/9668069/14817bc8-5288-11e5-993b-8eebe31ead6f.gif)
### After

...I was playing in dev tools. :smile: 

![2](https://cloud.githubusercontent.com/assets/2864371/9668073/19d33238-5288-11e5-9d1a-5fe7e54d0fa7.gif)

:balloon: 
