### PR TITLE
Rename file in order to avoid issue on Windows

### DIFF
--- a/CONTRIBUTORS/add-willwalsh96.txt
+++ b/CONTRIBUTORS/add-willwalsh96.txt
@@ -1,0 +1,1 @@
+willwalsh96

--- a/CONTRIBUTORS/add-willwalsh96.txt.
+++ b/CONTRIBUTORS/add-willwalsh96.txt.
@@ -1,1 +1,0 @@
-willwalsh96


### PR DESCRIPTION
Remove point at the end of filename in order to avoir following error on Windows : 

error: invalid path 'CONTRIBUTORS/add-willwalsh96.txt.'
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.